### PR TITLE
Fix bad block handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Fork
 This is a fork of https://github.com/dad4x/s4-3b1-pc7300 with fixes
 to work with my images of 3b1 disk drives.
 
+A fork of my fork is at 
+https://github.com/arnoldrobbins/s4-3b1-pc7300/ that the sysv driver has been
+updated to work with Ubuntu 18.04.
+
+
+Rest of this is the original readme.
+
 Purpose
 =======
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Fork
+====
+This is a fork of https://github.com/dad4x/s4-3b1-pc7300 with fixes
+to work with my images of 3b1 disk drives.
+
 Purpose
 =======
 

--- a/s4d.c
+++ b/s4d.c
@@ -365,7 +365,7 @@ void s4dump( char *b, size_t len, int absolute, int width, int breaks )
 
 
 
-int s4_lba2pba( int lba, s4_bbt *bbt, int nbb, int lstrk )
+int s4_lba2pba( int lba, s4_bbt *bbt, int nbb, int lstrk, int heads )
 {
   int pba = lba + (lba/(lstrk)); /* one spare sector per track */
   int npba;
@@ -376,28 +376,34 @@ int s4_lba2pba( int lba, s4_bbt *bbt, int nbb, int lstrk )
       int hdsec = lba % lstrk;
       int i, cylsec;
       
-      for( i = 0 ; i < nbb ; i++ )
+      /* First entry is checksum so start at 1 */
+      for( i = 1 ; i < nbb ; i++ )
         {
-          cylsec = bbt[i].cyl;
+          cylsec = bbt[i].badblk + bbt[i].cyl * heads * (lstrk + 1);
           if( !cylsec )
             break;
 
           if( track == (cylsec / (lstrk+1)) && hdsec == (cylsec % (lstrk+1)) )
             {
-              npba = (track * (lstrk+1)) + 16;
+              /* Badblk is alternate track, convert to block. Last sector on
+                 track is alternate */
+              npba = bbt[i].altblk * (lstrk + 1) + lstrk;
 
-              printf("Mapping lba %d from pba %d to %d. BB cyl %d trk %d hdsec %d\n",
-                     lba, pba, npba, cylsec, track, hdsec );
+              printf("Mapping lba %d from pba %d to %d.\n",
+                     lba, pba, npba );
 
+              pba = npba;
               break;
             }
         }
     }
+
   return pba;
 }
 
 
 
+/* strk is physical sectors per track */
 int s4_pba2lba( int pba, struct s4_bbe *bbt, int nbb, int strk, int heads )
 {
   int lba   = pba - (pba/strk);
@@ -409,15 +415,18 @@ int s4_pba2lba( int pba, struct s4_bbe *bbt, int nbb, int strk, int heads )
       if( nbb )
         {
           int track = pba / strk;
-          int i, cylsec;
+          int i;
 
-          for( i = 0; i < nbb ; i++ )
+          /* First entry is checksum so start at 1 */
+          for( i = 1; i < nbb ; i++ )
             {
-              cylsec = bbt[i].cyl;
-              if( track == (cylsec/strk) )
+              /* If track is alternate block location map to bad sector
+                 location */
+              if( track == bbt[i].altblk ) 
                 {
-                  /* this is almost certainly wrong: test & FIXME */
-                  lba = (track * (strk-1)) + ((cylsec % strk) % heads);
+                  /* Convert remapped sector to pba then lba */
+                  lba = bbt[i].cyl * heads * strk + bbt[i].badblk;
+                  lba = lba - (lba / strk);
                 }
             }
         }
@@ -427,7 +436,6 @@ int s4_pba2lba( int pba, struct s4_bbe *bbt, int nbb, int strk, int heads )
         }
     }
   
-
   return lba;
 }
 
@@ -1294,6 +1302,7 @@ void s4_fsu_swap( s4_fsu *fsu, int btype )
         for( i = 0; i < S4_NBB && fsu->bbt[ i ].cyl ; i++ )
           {
             fsu->bbt[ i ].cyl    = s4swaph( fsu->bbt[ i ].cyl );
+            fsu->bbt[ i ].badblk = s4swaph( fsu->bbt[ i ].badblk );
             fsu->bbt[ i ].altblk = s4swaph( fsu->bbt[ i ].altblk );
             fsu->bbt[ i ].nxtind = s4swaph( fsu->bbt[ i ].nxtind );
           }
@@ -1670,8 +1679,8 @@ static void s4_vol_bbt_show( s4_vol *vinfo )
     {
       printf("Bad Block table at blk %d sum 0x%x %d entries\n",
              vinfo->bbt_ba, vinfo->bbt[0].cyl, vinfo->nbb );
-      printf(" Cyl  cylsec  trk  sec     cyl sector nxt\n");
-      printf("----  ------  ---  ---    ---- ------ ---\n");
+      printf(" Cyl  cylsec  head  sec     cyl  head  nxt\n");
+      printf("----  ------  ----  ---     ---  ----  ---\n");
 
       /* first entry is the checksum; ignore */
       bbe = &vinfo->bbt[1];
@@ -1683,13 +1692,13 @@ static void s4_vol_bbt_show( s4_vol *vinfo )
           cylsec = bbe->badblk;
           altblk = bbe->altblk;
 
-          printf("%4d: %6d  %4d %3d ->%5d %6d %3d\n",
+          printf("%4d: %6d  %4d %4d -> %4d %5d %4d\n",
                  bbe->cyl,
                  cylsec,
                  cylsec / vinfo->pstrk,
                  cylsec % vinfo->pstrk,
-                 cylsec / vinfo->pstrk,
-                 altblk,
+                 altblk / vinfo->heads,
+                 altblk % vinfo->heads,
                  bbe->nxtind );
         }
       printf("%d bad blocks\n\n", i);

--- a/s4d.c
+++ b/s4d.c
@@ -830,10 +830,12 @@ static void s4_vol_get_bbt( s4_vol *vinfo )
                       sizeof(vinfo->bbt_fsu.buf));
   if( s4_ok == rv )
     {
-      /* if bb turned off, go physical. */
+      /* if bb turned off, go physical. Don't do this for real disks with
+         17 sectors per track */
       printf("BBT CHKSUM %x\n", vinfo->bbt[0].cyl );
       if( vinfo->bbt[0].cyl == S4_NO_BB_CHECKSUM &&
-          vinfo->bbt[0].badblk == S4_NO_BB_CHECKSUM )
+          vinfo->bbt[0].badblk == S4_NO_BB_CHECKSUM &&
+          vinfo->pstrk != 17)
         {
           printf("PHYSICAL!\n");
           vinfo->lba_or_pba = s4a_pba;

--- a/s4d.h
+++ b/s4d.h
@@ -595,10 +595,10 @@ typedef struct
 
 /* converting LBA to physical involves looking at bad block table */
 #define LBA_TO_VOL_PBA( d, lba ) \
-  s4_lba2pba( lba, (d)->bbt, (d)->nbb, (d)->lstrk )
+  s4_lba2pba( lba, (d)->bbt, (d)->nbb, (d)->lstrk, (d)->heads )
 
 #define LBA_TO_FS_PBA( xfs, lba ) \
-  s4_lba2pba( lba, (xfs)->bbt, (xfs)->nbb, (xfs)->vinfo->lstrk )
+  s4_lba2pba( lba, (xfs)->bbt, (xfs)->nbb, (xfs)->vinfo->lstrk, (xfs)->vinfo->heads )
 
 #define LBA_TO_VOL_OFFSET( d, lba ) \
   PBA_TO_OFFSET(d, LBA_TO_VOL_PBA( d, lba ))
@@ -678,7 +678,7 @@ s4err  s4_seek_write( int fd, int offset, char *buf, int blen );
 
 
 /* do bad block mapping given a bad block table and strk */
-int s4_lba2pba( int lba, struct s4_bbe *bbt, int nbb, int lstrk );
+int s4_lba2pba( int lba, struct s4_bbe *bbt, int nbb, int lstrk, int heads );
 
 /* reverse map physical block to lba.  FIXME - May not be useful. */
 int s4_pba2lba( int pba, struct s4_bbe *bbt, int nbb, int strk, int heads );

--- a/s4disk.c
+++ b/s4disk.c
@@ -165,7 +165,7 @@ static void s4_steal_vol_header( s4_vol *vinfo )
 {
   FILE *fp;
   char  nbuf[ 80 ];
-  char  fnbuf[ 80 ];
+  char  fnbuf[ 84 ];
   char  ebuf[ 1024 ];           /* encoded */
   char  pbuf[ 1024 ];           /* plain back from encoding */
   int   elen, plen;

--- a/s4fixed.h
+++ b/s4fixed.h
@@ -13,6 +13,7 @@
 #endif
 
 #if __STDC_VERSION__ >= 199901L
+    #include <stdint.h>
 
     /* we have these automatically */
 

--- a/s4fs.c
+++ b/s4fs.c
@@ -241,6 +241,8 @@ int main( int argc, char **argv )
         case afblk:
           fblk   = curadr;
           lbar   = fblk * 2;
+          break;
+
         default:
           printf("oops\n");
           abort();

--- a/s4mkfs.c
+++ b/s4mkfs.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
         /* cap inodes */
         if(n > 65500/NBINODE)
         {
-          printf("Too many inode blocks, %ld max\n", 65500/NBINODE );
+          printf("Too many inode blocks, %d max\n", 65500/NBINODE );
           n = 65500/NBINODE;
         }
      

--- a/s4mkfs.c
+++ b/s4mkfs.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
         /* cap inodes */
         if(n > 65500/NBINODE)
         {
-          printf("Too many inode blocks, %d max\n", 65500/NBINODE );
+          printf("Too many inode blocks, %ld max\n", (long) 65500/NBINODE );
           n = 65500/NBINODE;
         }
      
@@ -321,7 +321,7 @@ void mkfile(struct inode *parent)
         in.i_number = ino;
      
         memset( db, 0, FSBSIZE );
-        memset( ib, 0, NFB );
+        memset( ib, 0,  sizeof(ib) );
         in.i_nlink = 1;
         in.i_size = 0;
 


### PR DESCRIPTION
Printing bad block table and extracting file system image wasn't working with images I had read from disks. Also fixed a complaint about mismatch on printf arguments.